### PR TITLE
Fix Rich UI responsiveness by separating UI from asyncio loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,8 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# ASEA-X runtime directory
+workdir/
+*.save
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,6 @@ pre-commit
 
 # Additional for agents
 #difflib
+langchain_community
+langchain_openai
+langchain_text_splitters

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 import logging
+import time
+import threading
 
 import typer
 from rich.console import Console
@@ -29,6 +31,14 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[RichHandler(rich_tracebacks=True)]
 )
+
+file_handler = logging.FileHandler("asea-x.log")
+file_handler.setLevel(logging.INFO)
+file_handler.setFormatter(logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+))
+
+logging.getLogger().addHandler(file_handler)
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -96,8 +106,12 @@ class ASEAX:
         if self.git_manager.is_initialized():
             self.git_manager.setup_hooks()
         
-        # Start UI
-        self.ui.start()
+        # DO NOT start the UI here.
+        # The UI is blocking (it uses input()) and would freeze the asyncio event loop.
+        # UI is started from the Typer command in src/main.py after the loop is running.
+        if self.ui:
+            # Make sure UI knows which asyncio loop to schedule work onto.
+            self.ui.set_loop(asyncio.get_running_loop())
         
         self.running = True
         logger.info("ASEA-X system started successfully")
@@ -418,20 +432,6 @@ class ASEAX:
         
         else:
             return f"Unknown monitor command: {subcommand}"
-    
-    async def interactive_session(self):
-        """Start interactive session with enhanced UI"""
-        # UI is already running, just wait for exit
-        console.print("[bold cyan]ASEA-X Interactive Mode[/bold cyan]")
-        console.print("UI is running. Use the terminal interface for commands.")
-        console.print("Type 'exit' in the UI or press Ctrl+C here to quit.\n")
-        
-        while self.running:
-            try:
-                await asyncio.sleep(1)
-            except KeyboardInterrupt:
-                break
-
 
 @app.command()
 def start(
@@ -454,45 +454,83 @@ def start(
     """Start ASEA-X system with enhanced features"""
     asea_x = ASEAX(workdir)
 
-    # Start system
+    # Create and set event loop (this loop will run in a BACKGROUND THREAD)
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
-    # Setup signal handlers (schedule stop on the running loop)
-    def signal_handler(signum, frame):
-        console.print("\n[yellow]Shutting down...[/yellow]")
-        # Schedule coroutine safely onto the existing loop
-        asyncio.run_coroutine_threadsafe(asea_x.stop(), loop)
-        loop.call_soon_threadsafe(loop.stop)
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
+    # Start system initialization on this loop
     try:
-        # Start system
         success = loop.run_until_complete(asea_x.start())
         if not success:
             console.print("[red]Failed to start ASEA-X[/red]")
+            loop.close()
             sys.exit(1)
-        
-        # Start interactive session if requested
-        if interactive:
-            if ui:
-                # UI runs in its own thread, just wait
-                console.print("[green]✅ Rich UI started. Switch to UI window for interaction.[/green]")
-                console.print("[yellow]⚠️  This terminal is now for monitoring only.[/yellow]")
-            loop.run_until_complete(asea_x.interactive_session())
-        else:
-            # Keep running for API mode
-            console.print("[yellow]Running in API mode. Press Ctrl+C to exit.[/yellow]")
+
+        # Background thread that runs the asyncio loop forever
+        def run_loop():
+            asyncio.set_event_loop(loop)
             loop.run_forever()
-            
+
+        loop_thread = threading.Thread(target=run_loop, daemon=True)
+        loop_thread.start()
+
+        # Setup signal handlers (run in MAIN thread)
+        def signal_handler(signum, frame):
+            console.print("\n[yellow]Shutting down...[/yellow]")
+            # Tell UI to stop
+            try:
+                asea_x.ui.running = False
+                asea_x.ui.stop()
+            except Exception:
+                pass
+
+            # Stop system asynchronously
+            try:
+                fut = asyncio.run_coroutine_threadsafe(asea_x.stop(), loop)
+                fut.result(timeout=10)
+            except Exception:
+                pass
+
+            # Stop loop
+            loop.call_soon_threadsafe(loop.stop)
+
+        signal.signal(signal.SIGINT, signal_handler)
+        signal.signal(signal.SIGTERM, signal_handler)
+
+        if ui:
+            console.print("[green]✅ Rich UI started.[/green]")
+            console.print("[yellow]Press Ctrl+C to exit.[/yellow]")
+
+            # IMPORTANT: UI runs in MAIN thread (blocking input)
+            asea_x.ui.start()
+        else:
+            console.print("[yellow]Running without UI. Press Ctrl+C to exit.[/yellow]")
+            # If no UI, just wait here while loop runs
+            try:
+                while True:
+                    time.sleep(0.5)
+            except KeyboardInterrupt:
+                pass
+
     except KeyboardInterrupt:
         console.print("\n[yellow]Shutting down...[/yellow]")
     finally:
-        loop.run_until_complete(asea_x.stop())
-        loop.close()
+        # Clean shutdown
+        try:
+            fut = asyncio.run_coroutine_threadsafe(asea_x.stop(), loop)
+            fut.result(timeout=10)
+        except Exception:
+            pass
 
+        loop.call_soon_threadsafe(loop.stop)
+
+        # Give background loop thread time to exit
+        try:
+            loop_thread.join(timeout=2)
+        except Exception:
+            pass
+
+        loop.close()
 
 @app.command()
 def demo():

--- a/src/ui/terminal_ui.py
+++ b/src/ui/terminal_ui.py
@@ -38,7 +38,7 @@ class UIEvent:
 class TerminalUI:
     """
     Rich terminal-based UI for ASEA-X
-    
+
     Features:
     1. Multi-panel layout
     2. Real-time updates
@@ -47,28 +47,28 @@ class TerminalUI:
     5. Interactive commands
     6. Colorful output
     """
-    
+
     def __init__(self, orchestrator=None):
         self.orchestrator = orchestrator
         self.console = Console()
         self.layout = Layout()
         self.live: Optional[Live] = None
-        
+
         # Event queue for async updates
         self.event_queue = Queue()
         self.running = False
         self.update_thread: Optional[threading.Thread] = None
-        
+
         # UI state
         self.messages: List[Dict[str, Any]] = []
         self.tasks: List[Dict[str, Any]] = []
         self.system_status: Dict[str, Any] = {}
         self.progress_data: Dict[str, float] = {}
         self.last_update = time.time()
-        
+
         # Setup layout
         self._setup_layout()
-        
+
         # Color themes
         self.themes = {
             "info": "cyan",
@@ -80,7 +80,12 @@ class TerminalUI:
             "agent": "green",
             "mode": "yellow"
         }
-    
+        # IMPORTANT:
+        # Don't grab an event loop here. In many apps (especially Python 3.12+),
+        # the loop you get here may not be the running loop used by the orchestrator.
+        # We'll set the correct running loop later.
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+
     def _setup_layout(self):
         """Setup the terminal layout"""
         # Create layout structure
@@ -89,33 +94,33 @@ class TerminalUI:
             Layout(name="main"),
             Layout(name="footer", size=3)
         )
-        
+
         # Split main area
         self.layout["main"].split_row(
             Layout(name="left", ratio=2),
             Layout(name="right", ratio=1)
         )
-        
+
         # Split left area
         self.layout["left"].split_column(
             Layout(name="messages", ratio=3),
             Layout(name="progress", size=5)
         )
-        
+
         # Split right area
         self.layout["right"].split_column(
             Layout(name="status", size=10),
             Layout(name="tasks", ratio=2)
         )
-    
+
     def start(self):
         """Start the UI"""
         self.running = True
-        
+
         # Start update thread
         self.update_thread = threading.Thread(target=self._update_loop, daemon=True)
         self.update_thread.start()
-        
+
         # Start live display
         self.live = Live(
             self.layout,
@@ -123,35 +128,45 @@ class TerminalUI:
             refresh_per_second=4,
             screen=False
         )
-        
+
         with self.live:
             self._main_loop()
-    
+
     def stop(self):
         """Stop the UI"""
         self.running = False
         if self.update_thread:
             self.update_thread.join(timeout=2)
-        
+
         if self.live:
             self.live.stop()
-    
+
+    def _pause_updates(self):
+        self._updates_paused = True
+
+    def _resume_updates(self):
+        self._updates_paused = False
+
     def post_event(self, event: UIEvent):
         """Post an event to the UI"""
         self.event_queue.put(event)
-    
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop):
+        """Set the asyncio loop that is actually running the orchestrator."""
+        self.loop = loop
+
     def _update_loop(self):
         """Background update loop"""
         while self.running:
             try:
                 # Process events
-                while True:
+                for _ in range(50):
                     try:
                         event = self.event_queue.get_nowait()
                         self._handle_event(event)
                     except Empty:
                         break
-                
+
                 # Update UI components
                 self._update_header()
                 self._update_messages()
@@ -159,13 +174,13 @@ class TerminalUI:
                 self._update_tasks()
                 self._update_progress()
                 self._update_footer()
-                
+
                 time.sleep(0.25)  # Update 4 times per second
-                
+
             except Exception as e:
                 self.console.print(f"[red]UI Update Error: {e}[/red]")
                 time.sleep(1)
-    
+
     def _handle_event(self, event: UIEvent):
         """Handle UI events"""
         if event.type == "message":
@@ -175,11 +190,11 @@ class TerminalUI:
                 "sender": event.data.get("sender", "system"),
                 "timestamp": event.timestamp
             })
-            
+
             # Keep only last 50 messages
             if len(self.messages) > 50:
                 self.messages = self.messages[-50:]
-        
+
         elif event.type == "error":
             self.messages.append({
                 "type": "error",
@@ -187,7 +202,7 @@ class TerminalUI:
                 "sender": event.data.get("sender", "system"),
                 "timestamp": event.timestamp
             })
-        
+
         elif event.type == "update":
             if "status" in event.data:
                 self.system_status.update(event.data["status"])
@@ -195,30 +210,77 @@ class TerminalUI:
                 self.tasks = event.data["tasks"]
             if "progress" in event.data:
                 self.progress_data.update(event.data["progress"])
-        
+
         elif event.type == "command":
-            # Handle command input
-            pass
-    
+            command = event.data.get("input", "").strip()
+
+            if not command or not self.orchestrator:
+                return
+
+            # Allow exit from UI
+            if command.lower() in {"exit", "/exit", "quit", "q"}:
+                self.running = False
+                return
+
+            # Ensure we have a running asyncio loop
+            if self.loop is None or not self.loop.is_running():
+                self.post_event(UIEvent(
+                    type="error",
+                    data={
+                        "content": "Async loop is not running (UI.loop not set). "
+                                   "Call ui.set_loop(asyncio.get_running_loop()) from the async startup code.",
+                        "sender": "system"
+                    }
+                ))
+                return
+
+            # Schedule the coroutine on the running loop (NON-BLOCKING)
+            future = asyncio.run_coroutine_threadsafe(
+                self.orchestrator.process_input(command),
+                self.loop
+            )
+
+            def _done_callback(fut):
+                try:
+                    result = fut.result()
+                    if result:
+                        self.post_event(UIEvent(
+                            type="message",
+                            data={"content": result, "sender": "system"}
+                        ))
+                except Exception as e:
+                    self.post_event(UIEvent(
+                        type="error",
+                        data={"content": str(e), "sender": "system"}
+                    ))
+
+            future.add_done_callback(_done_callback)
+
     def _main_loop(self):
         """Main UI loop for input handling"""
         while self.running:
+            if getattr(self, "_updates_paused", False):
+                time.sleep(0.05)
+                continue
+
             try:
                 # Get user input
                 prompt = self._get_input_prompt()
-                user_input = Prompt.ask(prompt)
-                
-                if user_input.strip().lower() in ['exit', 'quit', 'q']:
-                    self.running = False
-                    break
-                
-                # Post command event
-                self.post_event(UIEvent(
-                    type="command",
-                    data={"input": user_input}
-                ))
-                
-                # Echo user input
+
+                # Temporarily suspend Live to allow stdin
+                if self.live:
+                    self.live.stop()
+
+                try:
+                    self.console.print(prompt, end="")
+                    user_input = input()
+                finally:
+                    if self.live:
+                        self.live.start()
+                        # Force a repaint immediately after restarting Live
+                        self.live.refresh()
+
+                # Always echo user input first
                 self.post_event(UIEvent(
                     type="message",
                     data={
@@ -226,7 +288,32 @@ class TerminalUI:
                         "sender": "user"
                     }
                 ))
-                
+
+                # Give the update thread a moment to consume the event
+                time.sleep(0.02)
+
+                # Force UI refresh so the message shows immediately
+                if self.live:
+                    self.live.refresh()
+
+                # Always send input into the pipeline
+                self.post_event(UIEvent(
+                    type="command",
+                    data={"input": user_input}
+                ))
+
+                # Give the update thread a moment to consume the command event too
+                time.sleep(0.02)
+
+                # Refresh again
+                if self.live:
+                    self.live.refresh()
+
+                # Now handle exit conditions
+                if user_input.strip().lower() in ['exit', 'quit', 'q', '/exit']:
+                    self.running = False
+                    break
+
             except KeyboardInterrupt:
                 self.console.print("\n[yellow]Interrupted. Press Ctrl+C again to exit.[/yellow]")
                 try:
@@ -239,15 +326,15 @@ class TerminalUI:
                 break
             except Exception as e:
                 self.console.print(f"[red]Input error: {e}[/red]")
-    
+
     def _get_input_prompt(self) -> str:
         """Get formatted input prompt"""
         if not self.orchestrator:
             return "[cyan]asea-x>[/cyan] "
-        
+
         state = self.orchestrator.state_manager.get_state()
         mode = state.current_mode
-        
+
         # Color code based on mode
         mode_colors = {
             "chat": "cyan",
@@ -256,23 +343,23 @@ class TerminalUI:
             "debug": "red",
             "lint": "magenta"
         }
-        
+
         color = mode_colors.get(mode, "white")
         return f"[{color}]{mode}[/{color}]> "
-    
+
     def _update_header(self):
         """Update header panel"""
         title = Text("ASEA-X - Autonomous Software Engineering Agent", style="bold blue")
         subtitle = Text("Multi-Agent System for Software Development", style="dim")
-        
+
         # Mode indicator
         if self.orchestrator:
             state = self.orchestrator.state_manager.get_state()
             mode_text = Text(f"Mode: {state.current_mode.upper()}", style="bold yellow")
-            
+
             # Safety indicator
             safety_text = Text("🔒 SAFE", style="bold green") if state.safety_enabled else Text("⚠️ UNSAFE", style="bold red")
-            
+
             header_content = Group(
                 title,
                 subtitle,
@@ -281,7 +368,7 @@ class TerminalUI:
             )
         else:
             header_content = Group(title, subtitle)
-        
+
         self.layout["header"].update(
             Panel(
                 header_content,
@@ -289,7 +376,7 @@ class TerminalUI:
                 padding=(1, 2)
             )
         )
-    
+
     def _update_messages(self):
         """Update messages panel"""
         messages_table = Table(
@@ -298,21 +385,21 @@ class TerminalUI:
             box=None,
             expand=True
         )
-        
+
         messages_table.add_column("Time", width=8)
         messages_table.add_column("From", width=10)
         messages_table.add_column("Message", ratio=1)
-        
+
         for msg in self.messages[-15:]:  # Show last 15 messages
             # Format time
             dt = datetime.fromtimestamp(msg["timestamp"])
             time_str = dt.strftime("%H:%M:%S")
-            
+
             # Format sender with color
             sender = msg["sender"]
             sender_color = self.themes.get(sender, "white")
             sender_text = Text(sender, style=sender_color)
-            
+
             # Format message with type-based styling
             content = msg["content"]
             if msg["type"] == "error":
@@ -323,13 +410,13 @@ class TerminalUI:
                 message_text = Text(content, style="blue")
             else:
                 message_text = Text(content)
-            
+
             # Truncate long messages
             if len(content) > 100:
                 message_text = Text(content[:97] + "...")
-            
+
             messages_table.add_row(time_str, sender_text, message_text)
-        
+
         self.layout["messages"].update(
             Panel(
                 messages_table,
@@ -338,7 +425,7 @@ class TerminalUI:
                 padding=(0, 1)
             )
         )
-    
+
     def _update_status(self):
         """Update status panel"""
         status_table = Table(
@@ -346,10 +433,10 @@ class TerminalUI:
             box=None,
             expand=True
         )
-        
+
         status_table.add_column("Metric", style="cyan")
         status_table.add_column("Value", style="white")
-        
+
         # Add status items
         if self.system_status:
             for key, value in self.system_status.items():
@@ -357,14 +444,14 @@ class TerminalUI:
                     status_table.add_row(key, str(value))
         else:
             status_table.add_row("Status", "Initializing...")
-        
+
         # Add mode info
         if self.orchestrator:
             state = self.orchestrator.state_manager.get_state()
             status_table.add_row("Current Mode", state.current_mode)
             status_table.add_row("Tasks", str(len(self.tasks)))
             status_table.add_row("Files", str(len(state.file_context)))
-        
+
         self.layout["status"].update(
             Panel(
                 status_table,
@@ -373,7 +460,7 @@ class TerminalUI:
                 padding=(1, 1)
             )
         )
-    
+
     def _update_tasks(self):
         """Update tasks panel"""
         tasks_table = Table(
@@ -382,16 +469,16 @@ class TerminalUI:
             box=None,
             expand=True
         )
-        
+
         tasks_table.add_column("ID", width=8)
         tasks_table.add_column("Status", width=10)
         tasks_table.add_column("Description", ratio=1)
-        
+
         for task in self.tasks[-10:]:  # Show last 10 tasks
             task_id = task.get("id", "N/A")
             status = task.get("status", "unknown")
             description = task.get("description", "")
-            
+
             # Color code status
             status_colors = {
                 "pending": "yellow",
@@ -400,16 +487,16 @@ class TerminalUI:
                 "failed": "red",
                 "cancelled": "dim"
             }
-            
+
             status_style = status_colors.get(status, "white")
             status_text = Text(status.upper(), style=status_style)
-            
+
             # Truncate description
             if len(description) > 30:
                 description = description[:27] + "..."
-            
+
             tasks_table.add_row(task_id, status_text, description)
-        
+
         self.layout["tasks"].update(
             Panel(
                 tasks_table,
@@ -418,7 +505,7 @@ class TerminalUI:
                 padding=(0, 1)
             )
         )
-    
+
     def _update_progress(self):
         """Update progress panel"""
         if not self.progress_data:
@@ -427,7 +514,7 @@ class TerminalUI:
             text = TextColumn("[progress.description]{task.description}")
             progress_bar = Progress(spinner, text, console=self.console)
             task_id = progress_bar.add_task("[cyan]Waiting for tasks...", total=None)
-            
+
             self.layout["progress"].update(
                 Panel(
                     progress_bar,
@@ -444,10 +531,10 @@ class TerminalUI:
                 TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
                 console=self.console
             )
-            
+
             for task_name, percent in self.progress_data.items():
                 progress.add_task(f"[cyan]{task_name}", total=100, completed=percent*100)
-            
+
             self.layout["progress"].update(
                 Panel(
                     progress,
@@ -456,7 +543,7 @@ class TerminalUI:
                     padding=(1, 1)
                 )
             )
-    
+
     def _update_footer(self):
         """Update footer panel"""
         # Help text
@@ -466,27 +553,27 @@ class TerminalUI:
         help_text.append("/mode ", style="green")
         help_text.append("/status ", style="yellow")
         help_text.append("/exit", style="red")
-        
+
         # Mode info
         if self.orchestrator:
             mode_manager = self.orchestrator.mode_manager
             current_mode = mode_manager.current_mode
-            
+
             mode_text = Text()
             mode_text.append("Current mode: ", style="dim")
             mode_text.append(current_mode.value.upper(), style="bold yellow")
-            
+
             # Suggested next mode
             suggested = mode_manager.suggest_next_mode({})
             if suggested:
                 mode_text.append(" → Next: ", style="dim")
                 mode_text.append(suggested.value.upper(), style="bold green")
-        
+
         else:
             mode_text = Text("Starting up...", style="dim")
-        
+
         footer_content = Group(help_text, Text(""), mode_text)
-        
+
         self.layout["footer"].update(
             Panel(
                 footer_content,
@@ -494,7 +581,7 @@ class TerminalUI:
                 padding=(0, 1)
             )
         )
-    
+
     def display_message(self, message: str, sender: str = "system", msg_type: str = "message"):
         """Display a message in the UI"""
         self.post_event(UIEvent(
@@ -504,43 +591,43 @@ class TerminalUI:
                 "sender": sender
             }
         ))
-    
+
     def display_error(self, error: str):
         """Display an error in the UI"""
         self.display_message(error, "system", "error")
-    
+
     def update_system_status(self, status: Dict[str, Any]):
         """Update system status display"""
         self.post_event(UIEvent(
             type="update",
             data={"status": status}
         ))
-    
+
     def update_tasks(self, tasks: List[Dict[str, Any]]):
         """Update tasks display"""
         self.post_event(UIEvent(
             type="update",
             data={"tasks": tasks}
         ))
-    
+
     def update_progress(self, progress: Dict[str, float]):
         """Update progress display"""
         self.post_event(UIEvent(
             type="update",
             data={"progress": progress}
         ))
-    
+
     def display_code(self, code: str, language: str = "python"):
         """Display code with syntax highlighting"""
         syntax = Syntax(code, language, theme="monokai", line_numbers=True)
         self.console.print(Panel(syntax, title="Code", border_style="green"))
-    
+
     def display_diff(self, diff: str):
         """Display a diff"""
         # Parse and colorize diff
         lines = diff.split('\n')
         colored_lines = []
-        
+
         for line in lines:
             if line.startswith('+'):
                 colored_lines.append(f"[green]{line}[/green]")
@@ -550,35 +637,35 @@ class TerminalUI:
                 colored_lines.append(f"[cyan]{line}[/cyan]")
             else:
                 colored_lines.append(line)
-        
+
         diff_text = '\n'.join(colored_lines)
         self.console.print(Panel(diff_text, title="Changes", border_style="yellow"))
-    
+
     def display_table(self, data: List[List[Any]], headers: List[str], title: str = ""):
         """Display data in a table"""
         table = Table(title=title, show_header=True, header_style="bold")
-        
+
         for header in headers:
             table.add_column(header)
-        
+
         for row in data:
             table.add_row(*[str(cell) for cell in row])
-        
+
         self.console.print(table)
-    
+
     def ask_question(self, question: str, default: Optional[str] = None) -> str:
         """Ask a question and get response"""
         return Prompt.ask(f"[cyan]{question}[/cyan]", default=default)
-    
+
     def ask_confirmation(self, question: str, default: bool = False) -> bool:
         """Ask for confirmation"""
         return Confirm.ask(f"[yellow]{question}[/yellow]", default=default)
-    
+
     def show_waiting(self, message: str = "Processing..."):
         """Show waiting indicator"""
         with self.console.status(f"[cyan]{message}[/cyan]", spinner="dots"):
             time.sleep(0.1)  # Placeholder
-    
+
     def clear_screen(self):
         """Clear the screen"""
         self.console.clear()


### PR DESCRIPTION
## What changed
- Prevented blocking Rich UI (`ui.start()`) from running inside async startup (`ASEAX.start()`).
- Ensured asyncio loop runs continuously while UI reads input.
- Added a `set_loop()` mechanism in TerminalUI so `run_coroutine_threadsafe()` targets the correct running loop.
- Improved immediate UI refresh after input.

## Why
Previously the async startup invoked a blocking UI loop which prevented the asyncio loop from running, causing delayed rendering and `coroutine was never awaited` warnings.

## How to test
1. `python3 -m src.main start`
2. Type `hello` → user message should appear immediately
3. Type `/planner` → system response should show without needing extra input
4. Press Ctrl+C → clean shutdown

## Linked Issue
Closes #1 
